### PR TITLE
Replace missing reactive

### DIFF
--- a/apps/session_one_app/app.R
+++ b/apps/session_one_app/app.R
@@ -36,10 +36,14 @@ ui <- fluidPage(
 
 # calculations behind the scenes
 server <- function(input, output) {
-
-    output$mortalityPlot <- renderPlot({
+    
+    selected_df <- reactive({
         mortality_zaf %>%
-            filter(province %in% input$province) %>%
+            filter(province %in% input$province)
+    })
+    
+    output$mortalityPlot <- renderPlot({
+        selected_df() %>%
             ggplot(aes(year, deaths, color = indicator)) +
             geom_line(alpha = 0.8, size = 1.5) +
             facet_wrap(~province, scales = "free") +


### PR DESCRIPTION
Noticed this was broken/missing so here's the obvious fix. 

Looks like you may only want to address reactive()'s in session two though, so if you don't want this done here then I assume you may have intended to either duplicate the dplyr::filter etc directly in both renderPlot and renderDataTable() or otherwise to just remove the data table view on this version?